### PR TITLE
make ResolveNow non block

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -96,7 +96,7 @@ func (c *resolver) watcher() {
 		}
 
 		if err != nil {
-			c.logger.Errorln(err.Error())
+			c.logger.Errorln(err)
 			// wait for next iteration
 		}
 

--- a/resolver.go
+++ b/resolver.go
@@ -43,7 +43,7 @@ func (c *resolver) ResolveNow(grpcresolver.ResolveNowOptions) {
 	}
 }
 
-func (c *resolver) cloudmapLookup() (*grpcresolver.State, error) {
+func (c *resolver) lookupCloudmap() (*grpcresolver.State, error) {
 	output, err := c.sd.DiscoverInstances(&servicediscovery.DiscoverInstancesInput{
 		NamespaceName: aws.String(c.namespace),
 		ServiceName:   aws.String(c.service),
@@ -88,7 +88,7 @@ func (c *resolver) watcher() {
 	defer c.wg.Done()
 
 	for {
-		state, err := c.cloudmapLookup()
+		state, err := c.lookupCloudmap()
 		if err != nil {
 			c.cc.ReportError(err)
 		} else {

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -1,0 +1,70 @@
+package cloudmap
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go/service/servicediscovery"
+	"google.golang.org/grpc/grpclog"
+	grpcresolver "google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/serviceconfig"
+	"testing"
+	"time"
+)
+
+type mockCC struct{}
+
+func (m mockCC) UpdateState(state grpcresolver.State) error { return nil }
+
+func (m mockCC) ReportError(err error) {}
+
+func (m mockCC) NewAddress(addresses []grpcresolver.Address) {}
+
+func (m mockCC) NewServiceConfig(serviceConfig string) {}
+
+func (m mockCC) ParseServiceConfig(serviceConfigJSON string) *serviceconfig.ParseResult {
+	return nil
+}
+
+type mockDiscovery struct{}
+
+func (m mockDiscovery) DiscoverInstances(input *servicediscovery.DiscoverInstancesInput) (*servicediscovery.DiscoverInstancesOutput, error) {
+	time.Sleep(1 * time.Second)
+	fmt.Println("DiscoverInstances called")
+	return &servicediscovery.DiscoverInstancesOutput{
+		Instances: make([]*servicediscovery.HttpInstanceSummary, 0),
+	}, nil
+}
+
+func Test_resolver(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	r := &resolver{
+		logger: grpclog.Component("test"),
+
+		cc: mockCC{},
+		sd: mockDiscovery{},
+
+		ctx:        ctx,
+		cancel:     cancel,
+		ticker:     time.NewTicker(10 * time.Second),
+		resolveCmd: make(chan struct{}, 1),
+	}
+
+	r.wg.Add(1)
+	go r.watcher()
+
+	timeout := time.After(100 * time.Millisecond)
+	done := make(chan bool)
+	go func() {
+		for i := 0; i < 10; i++ {
+			r.ResolveNow(grpcresolver.ResolveNowOptions{})
+		}
+		done <- true
+	}()
+	select {
+	case <-timeout:
+		t.Error("timeout")
+	case <-done:
+		t.Log("done")
+	}
+	r.Close()
+}


### PR DESCRIPTION
After #4 , it still cause a lot of goroutines.

In my case the goroutines are blocked at `google.golang.org/grpc.(*ccResolverWrapper).resolveNow` for many hours.

In previous PR #4 , I've fixed to return early to avoid multiple calls from `ClientConn.resolveNow`, but it blocked in `ccResolverWrapper.resolveNow` and  all goroutine is blocked when one goroutine is resolving cloudmap.

In this PR, I changed resolver not to block any goroutines referencing dnsResolver in grpc package.