### PR TITLE
make it possible to use newer google.golang.org/grpc

### DIFF
--- a/target.go
+++ b/target.go
@@ -22,7 +22,7 @@ type target struct {
 
 func parseTarget(t grpcresolver.Target) (*target, error) {
 	if t.URL.Scheme != Scheme {
-		return nil, fmt.Errorf("unexpected scheme: %s", t.Scheme)
+		return nil, fmt.Errorf("unexpected scheme: %s", t.URL.Scheme)
 	}
 
 	namespace, err := url.PathUnescape(t.URL.Host)


### PR DESCRIPTION
new versions of google.golang.org/grpc have completely removed the long deprecated Target.Scheme field.

This commit updates the code so that this module
can be imported into other modules using
more recent versions of the grpc Go module